### PR TITLE
Avoid infinite recursion

### DIFF
--- a/lib/micro-template.js
+++ b/lib/micro-template.js
@@ -61,9 +61,8 @@ function extended (id, data) {
 	return data ? fun(data) : fun;
 }
 
-template.get = function (id) {
-	var fun = extended.get || template.get;
-	return fun ? fun(id) : document.getElementById(id).innerHTML;
-};
+template.get = (function (get) {
+	return function (id) { return (extended.get || get)(id); };
+})(template.get);
 this.template = template;
 this.extended = extended;


### PR DESCRIPTION
If you don't define your own template.get() or extended.get(), calling template.get() causes infinite recursion. 
