### PR TITLE
V2: `with` の完全排除

### DIFF
--- a/lib/micro-template.js
+++ b/lib/micro-template.js
@@ -4,13 +4,13 @@
  */
 const template = function (id, data) {
 	if (arguments.length < 2) throw new Error('template() must be called with (template, data)');
-	const me = template, key = [id, Object.keys(data || {})];
+	const me = template, keys = Object.keys(data || {}), key = [id, keys];
 	if (!me.cache.has(key)) me.cache.set(key, (function () {
 		let name = id, string = /^[\w\-]+$/.test(id) ? me.get(id): (name = 'template(string)', id); // no warnings
 		let line = 1;
 		const body = (
 			`try { ` +
-				(me.variable ?  `let ${me.variable} = __this.stash;` : `with (__this.stash) { /*start*/`) +
+				(me.variable ?  `let ${me.variable} = __this.stash;` : ``) +
 				string.trim().split(/(<%.+?%>)/g).map(part =>
 					part.startsWith('<%=raw') && part.endsWith('%>') ? `/*raw*/__this.ret+=(${part.slice(6, -2)});` :
 					part.startsWith('<%=') && part.endsWith('%>')    ? `/*=*/__this.ret+=__this.escapeHTML(${part.slice(3, -2)});` :
@@ -22,16 +22,16 @@ const template = function (id, data) {
 						part ? `/*+*/__this.ret+='${part}';` : ''
 					)
 				).join('') +
-				`/*end*/ ${me.variable ? "" : "}"} return __this.ret;` +
+				`/*end*/ return __this.ret;` +
 			`} catch (e) { throw new Error('TemplateError: ' + e + ' (on ${name} line ' + __this.line + ')'); }` +
 			`//@ sourceURL=template.js\n`
 		);
-		const func = new Function("__this", body);
+		const func = new Function("__this", ...keys, body);
 		const map  = { '&' : '&amp;', '<' : '&lt;', '>' : '&gt;', '\x22' : '&#x22;', '\x27' : '&#x27;' };
 		const escapeHTML = function (string) { return (''+string).replace(/[&<>\'\"]/g, function (_) { return map[_] }) };
-		return function (stash) { return func.call(null, me.context = { escapeHTML: escapeHTML, line: 1, ret : '', stash: stash }) };
+		return function (stash, ...args) { return func.call(null, me.context = { escapeHTML: escapeHTML, line: 1, ret : '', stash: stash }, ...args) };
 	})());
-	return me.cache.get(key)(data);
+	return me.cache.get(key)(data, ...keys.map(key => data[key]));
 }
 template.cache = new Map();
 template.get = function (id) { return document.getElementById(id).innerHTML };

--- a/lib/micro-template.js
+++ b/lib/micro-template.js
@@ -3,8 +3,9 @@
  * (c) cho45 http://cho45.github.com/mit-license
  */
 const template = function (id, data) {
-	const me = template;
-	if (!me.cache[id]) me.cache[id] = (function () {
+	if (arguments.length < 2) throw new Error('template() must be called with (template, data)');
+	const me = template, key = [id, Object.keys(data || {})];
+	if (!me.cache.has(key)) me.cache.set(key, (function () {
 		let name = id, string = /^[\w\-]+$/.test(id) ? me.get(id): (name = 'template(string)', id); // no warnings
 		let line = 1;
 		const body = (
@@ -29,10 +30,10 @@ const template = function (id, data) {
 		const map  = { '&' : '&amp;', '<' : '&lt;', '>' : '&gt;', '\x22' : '&#x22;', '\x27' : '&#x27;' };
 		const escapeHTML = function (string) { return (''+string).replace(/[&<>\'\"]/g, function (_) { return map[_] }) };
 		return function (stash) { return func.call(null, me.context = { escapeHTML: escapeHTML, line: 1, ret : '', stash: stash }) };
-	})();
-	return data ? me.cache[id](data) : me.cache[id];
+	})());
+	return me.cache.get(key)(data);
 }
-template.cache = {};
+template.cache = new Map();
 template.get = function (id) { return document.getElementById(id).innerHTML };
 
 /**
@@ -71,7 +72,7 @@ function extended (id, data) {
 		return template(id, data);
 	};
 
-	return data ? fun(data) : fun;
+	return fun(data);
 }
 
 template.get = function (id) {


### PR DESCRIPTION
## 背景

with は既に非推奨であり、パフォーマンス的にも大きな負の側面がある https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Statements/with#browser_compatibility

いつなくなるかわからないものを標準動作としたくない

## 実装方法について

- テンプレート内で参照される変数を `with` 構文で束縛するのではなく、`Object.keys(data)` で取得した全てのキーを new Function の引数として展開し、ローカル変数として直接参照できるように。
- テンプレート関数生成時に `new Function("__this", ...keys, body)` の形で、dataの各プロパティ名を引数リストに追加。
- テンプレート実行時には `func.call(null, __this, ...keys.map(k => data[k]))` のように、dataの値を順番に渡す。
- これにより、テンプレート内で `foo` や `bar` のように素直に変数参照ができ、`with` の副作用やパフォーマンス問題を回避。
- なお、dataのキーが不正な識別子や予約語の場合はエラーとなるため、利用側で注意が必要（EJS等と同様の制約）。
- 既存の `__this` オブジェクトはエスケープや行番号管理用として引き続き利用。

## これにともなう破壊的な変更

- テンプレート関数 `template(t)` の1引数呼び出し（関数を返す）は廃止され、必ず `template(t, data)` の2引数で呼び出し、即座に変換済みの文字列を返す仕様に変更されました。
- これにより、従来の「テンプレート関数を返して後からデータを渡す」使い方はできなくなります。
- テンプレート内で参照できる変数は `data` オブジェクトのプロパティのみとなり、`with` による暗黙的なスコープ拡張は行われません。
- `data` のキーがJavaScriptの予約語や不正な識別子の場合、テンプレート生成時にエラーとなります（従来も同様の制約がありましたが、より顕在化します）。
- 既存のコードで1引数呼び出しや関数返却を利用している場合は、すべて `template(t, data)` 形式に修正が必要です。
