### PR TITLE
benchmark の not cached が適切ではない

### DIFF
--- a/lib/micro-template.js
+++ b/lib/micro-template.js
@@ -6,7 +6,7 @@ const template = function (id, data) {
 	if (arguments.length < 2) throw new Error('template() must be called with (template, data)');
 	const me = template, isArray = Array.isArray(data), keys = isArray ? data : Object.keys(data || {}), key = `data:${id}:${keys.sort().join(':')}`;
 	if (!me.cache.has(key)) me.cache.set(key, (function () {
-		let name = id, string = /^[\w\-]+$/.test(id) ? me.get(id): (name = `template-${Math.random().toString(36).slice(2)}`, id); // no warnings
+		let name = id, string = /^[\w\-]+$/.test(id) ? me.get(id): (name = `template-${id.charCodeAt(0)}`, id); // no warnings
 		let line = 1;
 		const body = (
 			`try {` +


### PR DESCRIPTION
同じコードが走ると最適化されるみたいなベンチの問題かも。

---

`name = 'template'`  な 場合と `name = 'template' + xxx `  な場合とで速さが違いすぎる。
```
  micro-template pre compiled
   1.02x faster than micro-template
   1.05x faster than micro-template (template.variable)
   1.72x faster than micro-template (not cached)
```
```
  micro-template pre compiled
   1.03x faster than micro-template
   1.03x faster than micro-template (template.variable)
   8.57x faster than micro-template (not cached)
```

挙動の調査

```
遅い
name. = `template-${Math.random().toString(36).slice(2)}` 8.7x
name = 'template' + (me.n=(me.n||0)+1) 8.25x
name = `template-${++counter}` # 8.54x
name = `template-${Date.now()}` # 6.15x

早い
name = `template-${id.slice(0, 10)}`; 1.72x
```

非決定的な外部要因が入ると遅くなる。このコード自体の速度とは関係ない
